### PR TITLE
Allow choosing a token env var name, and include a deploy comment

### DIFF
--- a/src/rollbar/orb.yml
+++ b/src/rollbar/orb.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 description: |
   Commands for calling the Rollbar deploy API.
-  Requires `curl` and `jq` commands to be available.
+  Requires `curl`, `git` and `jq` commands to be available.
   The source for the Orb can be found here:
   https://github.com/rollbar/rollbar-orb/tree/master/src/rollbar
 
@@ -29,6 +29,7 @@ commands:
                 --form access_token=${<< parameters.token_name >>} \
                 --form environment=<< parameters.environment >> \
                 --form revision=$CIRCLE_SHA1 \
+                --form comment="$(git show --no-patch --format=%s)"
                 --form local_username=$CIRCLE_USERNAME \
                 --form status=started | jq -r '.data.deploy_id'`
                 echo "Created deploy $ROLLBAR_DEPLOY_ID"
@@ -81,6 +82,7 @@ commands:
               --form access_token=${<< parameters.token_name >>} \
               --form environment=<< parameters.environment >> \
               --form revision=$CIRCLE_SHA1 \
+              --form comment="$(git show --no-patch --format=%s)"
               --form local_username=$CIRCLE_USERNAME
 
   upload_sourcemap:

--- a/src/rollbar/orb.yml
+++ b/src/rollbar/orb.yml
@@ -13,6 +13,10 @@ commands:
       Should be used in conjunction with notify_deploy_finished.
       Command will set a BASH ENV variable ROLLBAR_DEPLOY_ID with the ID of the deploy.
     parameters:
+      token_name:
+        type: env_var_name
+        default: ROLLBAR_ACCESS_TOKEN
+        description: The name of the rollbar token environment variable. Defaults to $ROLLBAR_ACCESS_TOKEN.
       environment:
         type: string
         default: production
@@ -22,7 +26,7 @@ commands:
             name: Rollbar - Notify Deploy Started
             command: |
               ROLLBAR_DEPLOY_ID=`curl https://api.rollbar.com/api/1/deploy/ \
-                --form access_token=$ROLLBAR_ACCESS_TOKEN \
+                --form access_token=${<< parameters.token_name >>} \
                 --form environment=<< parameters.environment >> \
                 --form revision=$CIRCLE_SHA1 \
                 --form local_username=$CIRCLE_USERNAME \
@@ -35,6 +39,10 @@ commands:
       A step to notify Rollbar that the deploy of a project has finished.
       Should be used in conjunction with notify_deploy_started.
     parameters:
+      token_name:
+        type: env_var_name
+        default: ROLLBAR_ACCESS_TOKEN
+        description: The name of the rollbar token environment variable. Defaults to $ROLLBAR_ACCESS_TOKEN.
       deploy_id:
         type: string
         description: The deploy_id of the deploy to update
@@ -46,7 +54,7 @@ commands:
             name: Rollbar - Notify Deploy Finished
             command: |
               curl -X PATCH \
-              https://api.rollbar.com/api/1/deploy/<< parameters.deploy_id>>?access_token=$ROLLBAR_ACCESS_TOKEN \
+              https://api.rollbar.com/api/1/deploy/<< parameters.deploy_id>>?access_token=${<< parameters.token_name >>} \
                 --data '{"status":"<< parameters.status >>"}'
 
   notify_deploy:
@@ -57,6 +65,10 @@ commands:
       Add this as the last step of your the job that you
       use to deploy.
     parameters:
+      token_name:
+        type: env_var_name
+        default: ROLLBAR_ACCESS_TOKEN
+        description: The name of the rollbar token environment variable. Defaults to $ROLLBAR_ACCESS_TOKEN.
       environment:
         type: string
         default: production
@@ -66,7 +78,7 @@ commands:
           name: Rollbar - Notify Deploy Succeeded
           command: |
             curl https://api.rollbar.com/api/1/deploy/ \
-              --form access_token=$ROLLBAR_ACCESS_TOKEN \
+              --form access_token=${<< parameters.token_name >>} \
               --form environment=<< parameters.environment >> \
               --form revision=$CIRCLE_SHA1 \
               --form local_username=$CIRCLE_USERNAME
@@ -74,6 +86,10 @@ commands:
   upload_sourcemap:
     description: A step to upload a sourcemap to Rollbar during a deploy.
     parameters:
+      token_name:
+        type: env_var_name
+        default: ROLLBAR_ACCESS_TOKEN
+        description: The name of the rollbar token environment variable. Defaults to $ROLLBAR_ACCESS_TOKEN.
       minified_url:
         type: string
         description:  The full URL of the minified file.
@@ -93,7 +109,7 @@ commands:
               done
             echo $JS_FILES
             curl https://api.rollbar.com/api/1/sourcemap \
-              -F access_token=$ROLLBAR_ACCESS_TOKEN \
+              -F access_token=${<< parameters.token_name >>} \
               -F version=$CIRCLE_SHA1\
               -F minified_url=<< parameters.minified_url >> \
               -F source_map=@<< parameters.source_map >> \


### PR DESCRIPTION
Making the token a parameter allows for using multiple tokens in a single job more easily.

As documented here: https://circleci.com/docs/2.0/reusing-config/#environment-variable-name

I've also included the short version of the git commit as the deploy comment


I haven't tested these changes yet - they're based on our own non-orb usage of rollbar, I wanted to post the PR for feedback. I'll look at running this as a dev orb and confirm back here when I know things are fully working.