### PR TITLE
Make js_files optional by using empty default

### DIFF
--- a/src/rollbar/orb.yml
+++ b/src/rollbar/orb.yml
@@ -83,6 +83,7 @@ commands:
       js_files:
         type: string
         description: An array of local paths to unminified javascript files.
+        default: ''
     steps:
       - run:
           name: Rollbar - Upload Sourcemap


### PR DESCRIPTION
Fixes https://github.com/rollbar/rollbar-orb/issues/8