### PR TITLE
add "when" parameter to the notify_deploy_finished

### DIFF
--- a/src/rollbar/orb.yml
+++ b/src/rollbar/orb.yml
@@ -41,6 +41,10 @@ commands:
       status:
         type: enum
         enum: ["succeeded","failed","timed_out"]
+      when:
+        type: enum
+        enum: ["on_fail","on_success","always"]
+        default: always
     steps:
         - run:
             name: Rollbar - Notify Deploy Finished
@@ -48,6 +52,7 @@ commands:
               curl -X PATCH \
               https://api.rollbar.com/api/1/deploy/<< parameters.deploy_id>>?access_token=$ROLLBAR_ACCESS_TOKEN \
                 --data '{"status":"<< parameters.status >>"}'
+            when: << parameters.when >>
 
   notify_deploy:
     description: |


### PR DESCRIPTION
Aa far as I got my head around the CircleCI and orb configuration, there's currently no way to run notify_deploy_finished with a different status depending on the CI workflow status.

First I came up with the following:
```yml
    steps:
      - run:
          name: Assume deploy is failed
          command: "echo \"export ROLLBAR_STATUS=failed\" >> $BASH_ENV"
      - deploy/notify_deploy_started:
          environment: ${ROLLBAR_ENVIRONMENT}
      - checkout
      - run:
          name: Run unit tests
          command: "composer install && php bin/phpunit && echo \"export ROLLBAR_STATUS=succeeded\" >> $BASH_ENV"
      - deploy/notify_deploy_finished:
          deploy_id: ${ROLLBAR_DEPLOY_ID}
          status: ${ROLLBAR_STATUS}
```
but Circle CI apparently does some static analysis before the workflow actually runs and disallows having `${ROLLBAR_STATUS}` as status.

Well, here's the other solution. Hope you like it.

Cheers,
Jakub